### PR TITLE
twister: Fix an issue with copying objects from testsuite

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -680,9 +680,6 @@ class Pytest(Script):
             except Exception as e:
                 logger.error(f'Error when parsing file {self.report_file}: {e}')
                 self.status = TwisterStatus.FAIL
-            finally:
-                if not self.instance.testcases:
-                    self.instance.init_cases()
 
         self.instance.status = self.status if self.status != TwisterStatus.NONE else \
                                TwisterStatus.FAIL

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -15,6 +15,7 @@ import os
 import random
 import re
 from enum import Enum
+from pathlib import Path
 
 from twisterlib.constants import (
     PYTEST_HARNESSES,
@@ -45,7 +46,7 @@ logger = logging.getLogger('twister')
 
 
 class TestInstance:
-    """Class representing the execution of a particular TestSuite on a platform
+    """Class representing the execution of a particular TestSuite on a platform.
 
     @param test The TestSuite object we want to build/execute
     @param platform Platform object that we want to build and run against
@@ -55,24 +56,24 @@ class TestInstance:
 
     __test__ = False
 
-    def __init__(self, testsuite, platform, toolchain, outdir):
-
+    def __init__(
+        self, testsuite: TestSuite, platform: Platform, toolchain: str, outdir: str | Path
+    ) -> None:
         self.testsuite: TestSuite = testsuite
         self.platform: Platform = platform
 
         self._status = TwisterStatus.NONE
-        self.reason = None
-        self.metrics = dict()
+        self.metrics: dict = dict()
         self.handler = None
         self.recording = None
         self.coverage = None
         self.coverage_status = None
         self.outdir = outdir
         self.execution_time = 0
-        self.build_time = 0
-        self.retries = 0
+        self.build_time: float = 0
+        self.retries: int = 0
         self.toolchain = toolchain
-        self.name = os.path.join(platform.name, toolchain, testsuite.name)
+        self.name: str = os.path.join(platform.name, toolchain, testsuite.name)
         self.hardware_id: str | None = None
         self.suite_repeat = None
         self.test_repeat = None
@@ -96,11 +97,9 @@ class TestInstance:
         self.run_id = None
         self.domains = None
         # Instance need to use sysbuild if a given suite or a platform requires it
-        self.sysbuild = testsuite.sysbuild or platform.sysbuild
+        self.sysbuild: bool = testsuite.sysbuild or platform.sysbuild
 
-        self.run = False
-        self.testcases: list[TestCase] = []
-        self.init_cases()
+        self.run: bool = False
         self.filters = []
         self.filter_type = None
         self.required_applications = []
@@ -130,11 +129,28 @@ class TestInstance:
                 cw.writerows(self.recording)
 
     @property
+    def reason(self):
+        return self.testsuite.reason
+
+    @reason.setter
+    def reason(self, value):
+        self.testsuite.reason = value
+
+    @property
+    def testcases(self) -> list[TestCase]:
+        return self.testsuite.testcases
+
+    @testcases.setter
+    def testcases(self, value: list[TestCase]):
+        self.testsuite.testcases = value
+
+    @property
     def status(self) -> TwisterStatus:
         return self._status
 
     @status.setter
     def status(self, value : TwisterStatus) -> None:
+        self.testsuite.status = value
         # Check for illegal assignments by value
         try:
             key = value.name if isinstance(value, Enum) else value
@@ -148,15 +164,10 @@ class TestInstance:
         self.reason = reason
         self.filter_type = filter_type
 
-    # Fix an issue with copying objects from testsuite, need better solution.
-    def init_cases(self):
-        for c in self.testsuite.testcases:
-            self.add_testcase(c.name, freeform=c.freeform)
-
     def _get_run_id(self):
-        """ generate run id from instance unique identifier and a random
-        number
-        If exist, get cached run id from previous run."""
+        """Generate run id from instance unique identifier and a random number.
+        If exist, get cached run id from previous run.
+        """
         run_id = ""
         run_id_file = os.path.join(self.build_dir, "run_id.txt")
         if os.path.exists(run_id_file):

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -378,13 +378,13 @@ def _find_src_dir_path(test_dir_path):
 class TestCase:
     __test__ = False
 
-    def __init__(self, name):
-        self.duration = 0
+    def __init__(self, name: str):
+        self.duration: float = 0
         self.name = name
         self._status = TwisterStatus.NONE
-        self.reason = None
-        self.output = ""
-        self.freeform = False
+        self.reason: str | None = None
+        self.output: str = ""
+        self.freeform: bool = False
 
     @property
     def status(self) -> TwisterStatus:
@@ -452,6 +452,7 @@ class TestSuite:
         self.ztest_suite_names = []
 
         self._status = TwisterStatus.NONE
+        self.reason: str | None = None
 
         self.harness_config: HarnessConfig | None = None
         self.required_applications: list[RequiredApplication] = []
@@ -464,7 +465,7 @@ class TestSuite:
         return self._status
 
     @status.setter
-    def status(self, value : TwisterStatus) -> None:
+    def status(self, value: TwisterStatus) -> None:
         # Check for illegal assignments by value
         try:
             key = value.name if isinstance(value, Enum) else value

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -280,29 +280,6 @@ def test_testinstance_add_filter(testinstance):
     assert testinstance.filter_type == filter_type
 
 
-def test_testinstance_init_cases(all_testsuites_dict, class_testplan, platforms_list):
-    testsuite_path = 'scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_1'
-    class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get(testsuite_path)
-    class_testplan.platforms = platforms_list
-    platform = class_testplan.get_platform("demo_board_2")
-
-    testinstance = TestInstance(testsuite, platform, 'zephyr', class_testplan.env.outdir)
-
-    testinstance.init_cases()
-
-    assert all(
-        [
-            any(
-                [
-                    tcc.name == tc.name and tcc.freeform == tc.freeform \
-                        for tcc in testinstance.testsuite.testcases
-                ]
-            ) for tc in testsuite.testcases
-        ]
-    )
-
-
 @pytest.mark.parametrize('testinstance', [{'testsuite_kind': 'sample'}], indirect=True)
 def test_testinstance_get_run_id(testinstance):
     res = testinstance._get_run_id()

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -20,7 +20,7 @@ from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.testplan import TestConfiguration, TestPlan, change_skip_to_error_if_integration
-from twisterlib.testsuite import TestSuite
+from twisterlib.testsuite import TestCase, TestSuite
 from twisterlib.testsuitedata import RequiredApplication
 
 
@@ -1630,28 +1630,24 @@ TESTDATA_11 = [
 )
 def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
     def get_platform(name):
-        p = mock.Mock()
+        p = Platform()
         p.name = name
         p.normalized_name = name
         return p
 
-    ts1tc1 = mock.Mock()
-    ts1tc1.name = 'TS1.tc1'
+    ts1tc1 = TestCase('TS1.tc1')
     ts1 = mock.Mock(testcases=[ts1tc1])
     ts1.name = 'TestSuite 1'
     ts1.toolchain = 'zephyr'
     ts2 = mock.Mock(testcases=[])
     ts2.name = 'TestSuite 2'
     ts2.toolchain = 'zephyr'
-    ts3tc1 = mock.Mock()
-    ts3tc1.name = 'TS3.tc1'
-    ts3tc2 = mock.Mock()
-    ts3tc2.name = 'TS3.tc2'
+    ts3tc1 = TestCase('TS3.tc1')
+    ts3tc2 = TestCase('TS3.tc2')
     ts3 = mock.Mock(testcases=[ts3tc1, ts3tc2])
     ts3.name = 'TestSuite 3'
     ts3.toolchain = 'zephyr'
-    ts4tc1 = mock.Mock()
-    ts4tc1.name = 'TS4.tc1'
+    ts4tc1 = TestCase('TS4.tc1')
     ts4 = mock.Mock(testcases=[ts4tc1])
     ts4.name = 'TestSuite 4'
     ts4.toolchain = 'zephyr'


### PR DESCRIPTION
Removed duplicated statuses for TestTnstance by using existing statuses from TestSuite.